### PR TITLE
Fetch requests in background script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "npm run build:plugin && rollup -c && npm run build:manifest",
-    "dev": "rollup -c -w",
+    "dev": "npm run build:manifest && rollup -c -w",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "start": "exit 0",
     "build:plugin": "tsc getrid-underscore-plugin.ts --moduleResolution node -m es6",

--- a/package.json
+++ b/package.json
@@ -23,21 +23,21 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
-    "@rollup/plugin-typescript": "^8.0.0",
+    "@rollup/plugin-typescript": "^8.3.2",
     "@tsconfig/svelte": "^2.0.1",
     "@types/firefox-webext-browser": "^94.0.1",
     "estree-walker": "2.0.1",
     "magic-string": "^0.26.2",
-    "rollup": "^2.3.4",
+    "rollup": "^2.74.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
-    "svelte": "^3.0.0",
-    "svelte-check": "^2.0.0",
-    "svelte-preprocess": "^4.0.0",
-    "tslib": "^2.0.0",
-    "typescript": "^4.0.0"
+    "svelte": "^3.48.0",
+    "svelte-check": "^2.7.1",
+    "svelte-preprocess": "^4.10.6",
+    "tslib": "^2.4.0",
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "query-string": "^7.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,46 +1,46 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@rollup/plugin-commonjs': ^17.0.0
   '@rollup/plugin-node-resolve': ^11.2.1
-  '@rollup/plugin-typescript': ^8.0.0
+  '@rollup/plugin-typescript': ^8.3.2
   '@tsconfig/svelte': ^2.0.1
   '@types/firefox-webext-browser': ^94.0.1
   estree-walker: 2.0.1
   magic-string: ^0.26.2
   query-string: ^7.1.1
-  rollup: ^2.3.4
+  rollup: ^2.74.1
   rollup-plugin-copy: ^3.4.0
   rollup-plugin-css-only: ^3.1.0
   rollup-plugin-svelte: ^7.0.0
   rollup-plugin-terser: ^7.0.0
-  svelte: ^3.0.0
-  svelte-check: ^2.0.0
-  svelte-preprocess: ^4.0.0
-  tslib: ^2.0.0
-  typescript: ^4.0.0
+  svelte: ^3.48.0
+  svelte-check: ^2.7.1
+  svelte-preprocess: ^4.10.6
+  tslib: ^2.4.0
+  typescript: ^4.6.4
 
 dependencies:
   query-string: 7.1.1
 
 devDependencies:
-  '@rollup/plugin-commonjs': 17.1.0_rollup@2.70.1
-  '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.1
-  '@rollup/plugin-typescript': 8.3.1_8fb0118e9d69f3600cbb8f144f7d456c
+  '@rollup/plugin-commonjs': 17.1.0_rollup@2.74.1
+  '@rollup/plugin-node-resolve': 11.2.1_rollup@2.74.1
+  '@rollup/plugin-typescript': 8.3.2_ewnwotriipvq7wps276zlnnxuy
   '@tsconfig/svelte': 2.0.1
   '@types/firefox-webext-browser': 94.0.1
   estree-walker: 2.0.1
   magic-string: 0.26.2
-  rollup: 2.70.1
+  rollup: 2.74.1
   rollup-plugin-copy: 3.4.0
-  rollup-plugin-css-only: 3.1.0_rollup@2.70.1
-  rollup-plugin-svelte: 7.1.0_rollup@2.70.1+svelte@3.46.6
-  rollup-plugin-terser: 7.0.2_rollup@2.70.1
-  svelte: 3.46.6
-  svelte-check: 2.4.6_svelte@3.46.6
-  svelte-preprocess: 4.10.4_svelte@3.46.6+typescript@4.6.3
-  tslib: 2.3.1
-  typescript: 4.6.3
+  rollup-plugin-css-only: 3.1.0_rollup@2.74.1
+  rollup-plugin-svelte: 7.1.0_urfczz6hd3bvh7smupyykzijga
+  rollup-plugin-terser: 7.0.2_rollup@2.74.1
+  svelte: 3.48.0
+  svelte-check: 2.7.1_svelte@3.48.0
+  svelte-preprocess: 4.10.6_wwvk7nlptlrqo2czohjtk6eiqm
+  tslib: 2.4.0
+  typescript: 4.6.4
 
 packages:
 
@@ -65,6 +65,22 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /@jridgewell/resolve-uri/3.0.7:
+    resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.13:
+    resolution: {integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.13:
+    resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.7
+      '@jridgewell/sourcemap-codec': 1.4.13
+    dev: true
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -86,53 +102,53 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@rollup/plugin-commonjs/17.1.0_rollup@2.70.1:
+  /@rollup/plugin-commonjs/17.1.0_rollup@2.74.1:
     resolution: {integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^2.30.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.74.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.0
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.0
-      rollup: 2.70.1
+      rollup: 2.74.1
     dev: true
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.70.1:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.74.1:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.74.1
       '@types/resolve': 1.17.1
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.22.0
-      rollup: 2.70.1
+      rollup: 2.74.1
     dev: true
 
-  /@rollup/plugin-typescript/8.3.1_8fb0118e9d69f3600cbb8f144f7d456c:
-    resolution: {integrity: sha512-84rExe3ICUBXzqNX48WZV2Jp3OddjTMX97O2Py6D1KJaGSwWp0mDHXj+bCGNJqWHIEKDIT2U0sDjhP4czKi6cA==}
+  /@rollup/plugin-typescript/8.3.2_ewnwotriipvq7wps276zlnnxuy:
+    resolution: {integrity: sha512-MtgyR5LNHZr3GyN0tM7gNO9D0CS+Y+vflS4v/PHmrX17JCkHUYKvQ5jN5o3cz1YKllM3duXUqu3yOHwMPUxhDg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rollup: ^2.14.0
       tslib: '*'
       typescript: '>=3.7.0'
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.74.1
       resolve: 1.22.0
-      rollup: 2.70.1
-      tslib: 2.3.1
-      typescript: 4.6.3
+      rollup: 2.74.1
+      tslib: 2.4.0
+      typescript: 4.6.4
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.70.1:
+  /@rollup/pluginutils/3.1.0_rollup@2.74.1:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -141,7 +157,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.70.1
+      rollup: 2.74.1
     dev: true
 
   /@rollup/pluginutils/4.2.0:
@@ -730,17 +746,17 @@ packages:
       is-plain-object: 3.0.1
     dev: true
 
-  /rollup-plugin-css-only/3.1.0_rollup@2.70.1:
+  /rollup-plugin-css-only/3.1.0_rollup@2.74.1:
     resolution: {integrity: sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==}
     engines: {node: '>=10.12.0'}
     peerDependencies:
       rollup: 1 || 2
     dependencies:
       '@rollup/pluginutils': 4.2.0
-      rollup: 2.70.1
+      rollup: 2.74.1
     dev: true
 
-  /rollup-plugin-svelte/7.1.0_rollup@2.70.1+svelte@3.46.6:
+  /rollup-plugin-svelte/7.1.0_urfczz6hd3bvh7smupyykzijga:
     resolution: {integrity: sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -748,19 +764,19 @@ packages:
       svelte: '>=3.5.0'
     dependencies:
       require-relative: 0.8.7
-      rollup: 2.70.1
+      rollup: 2.74.1
       rollup-pluginutils: 2.8.2
-      svelte: 3.46.6
+      svelte: 3.48.0
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.70.1:
+  /rollup-plugin-terser/7.0.2_rollup@2.74.1:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
       '@babel/code-frame': 7.16.7
       jest-worker: 26.6.2
-      rollup: 2.70.1
+      rollup: 2.74.1
       serialize-javascript: 4.0.0
       terser: 5.12.1
     dev: true
@@ -771,8 +787,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup/2.70.1:
-    resolution: {integrity: sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==}
+  /rollup/2.74.1:
+    resolution: {integrity: sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -883,22 +899,21 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-check/2.4.6_svelte@3.46.6:
-    resolution: {integrity: sha512-luzdly7RJhyXucQe8ID/7CqDgXdMrPYXmyZBjCbp+cixzTopZotuWevrB5hWDOnOU19m2cyetigIIa7WDHnCmQ==}
+  /svelte-check/2.7.1_svelte@3.48.0:
+    resolution: {integrity: sha512-vHVu2+SQ6ibt77iTQaq2oiOjBgGL48qqcg0ZdEOsP5pPOjgeyR9QbnaEdzdBs9nsVYBc/42haKtzb2uFqS8GVw==}
     hasBin: true
     peerDependencies:
       svelte: ^3.24.0
     dependencies:
+      '@jridgewell/trace-mapping': 0.3.13
       chokidar: 3.5.3
       fast-glob: 3.2.11
       import-fresh: 3.3.0
-      minimist: 1.2.6
       picocolors: 1.0.0
       sade: 1.8.1
-      source-map: 0.7.3
-      svelte: 3.46.6
-      svelte-preprocess: 4.10.4_svelte@3.46.6+typescript@4.6.3
-      typescript: 4.6.3
+      svelte: 3.48.0
+      svelte-preprocess: 4.10.6_wwvk7nlptlrqo2czohjtk6eiqm
+      typescript: 4.6.4
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -912,8 +927,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-preprocess/4.10.4_svelte@3.46.6+typescript@4.6.3:
-    resolution: {integrity: sha512-fuwol0N4UoHsNQolLFbMqWivqcJ9N0vfWO9IuPAiX/5okfoGXURyJ6nECbuEIv0nU3M8Xe2I1ONNje2buk7l6A==}
+  /svelte-preprocess/4.10.6_wwvk7nlptlrqo2czohjtk6eiqm:
+    resolution: {integrity: sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
     peerDependencies:
@@ -959,12 +974,12 @@ packages:
       magic-string: 0.25.9
       sorcery: 0.10.0
       strip-indent: 3.0.0
-      svelte: 3.46.6
-      typescript: 4.6.3
+      svelte: 3.48.0
+      typescript: 4.6.4
     dev: true
 
-  /svelte/3.46.6:
-    resolution: {integrity: sha512-o9nNft/OzCz/9kJpmWa1S52GAM+huCjPIsNWydYmgei74ZWlOA9/hN9+Z12INdklghu31seEXZMRHhS1+8DETw==}
+  /svelte/3.48.0:
+    resolution: {integrity: sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==}
     engines: {node: '>= 8'}
     dev: true
 
@@ -986,12 +1001,12 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tslib/2.3.1:
-    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
     dev: true
 
-  /typescript/4.6.3:
-    resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
+  /typescript/4.6.4:
+    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -56,9 +56,6 @@
   "openTranslator": {
     "message": "Open translator popup"
   },
-  "optionsOmitReferer": {
-    "message": "Omit Referer header in http request? May cause tts in inline popup not work after disabling it (disable it if you can't login to a website or website do something different)"
-  },
   "synonyms": {
     "message": "Synonyms"
   }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -56,9 +56,6 @@
   "openTranslator": {
     "message": "Buka popup penerjemah"
   },
-  "optionsOmitReferer": {
-    "message": "Hilangkan Referer header di http request? Bisa menyebabkan text-to-speech di inline popup tidak bekerja setelah menonaktifkan ini (matikan bila tidak bisa login di website atau website berlaku yang aneh-aneh)"
-  },
   "synonyms": {
     "message": "Sinonim"
   }

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,7 +5,6 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
     browser.storage.local.set({
       targetLang: 'en',
       altTargetLang: 'zh',
-      noReferer: true,
     });
   }
 });

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -69,6 +69,7 @@ function blobToDataURL(blob: Blob) {
   });
 }
 
+// handle all the request from content script
 browser.runtime.onMessage.addListener(async (msg, sender, sendRes) => {
   if (msg.name === 'tts-fetch') {
     const ttsLink = getTTSLink(msg.text, msg.langId);

--- a/src/background/main.html
+++ b/src/background/main.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Translight Background</title>
+  <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>
+  <script defer type="module" src="./background.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -1,5 +1,4 @@
 import Result from '../popup/Result.svelte';
-import gtrans from '../lib/gtrans';
 
 const gm = browser.i18n.getMessage;
 
@@ -122,7 +121,7 @@ document.addEventListener("mouseup", (e) => {
     container.style.padding = '5px';
     container = document.body.appendChild(container);
     const { targetLang } = await browser.storage.local.get('targetLang');
-    const translated = gtrans(selected, { to: targetLang });
+    const translated = browser.runtime.sendMessage({ name: 'gtrans-fetch', text: selected, gtransOptions: { to: targetLang } });
 
     const resComponent = new Result({
       target: container,

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -141,12 +141,3 @@ document.addEventListener('keydown', (e) => {
   }
   if (tooltip) tooltip.remove();
 });
-
-browser.storage.local.get('noReferer').then(res => {
-  if (!res.noReferer) return;
-  const metaNoRef = document.createElement('meta');
-  metaNoRef.name = "referrer";
-  metaNoRef.content = "no-referrer";
-  document.head.appendChild(metaNoRef);
-});
-

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,5 +6,4 @@ interface LocalStorage {
   altTargetLang?: string;
   windowURL?: string;
   selection?: string;
-  noReferer?: boolean;
 }

--- a/src/lib/gtrans.ts
+++ b/src/lib/gtrans.ts
@@ -346,12 +346,12 @@ async function translate(text: string, options: TransOptions): Promise<ReadableF
 
 export default translate;
 
-translate.validateLangId = (langCode: string): string | boolean => {
+export const validateLangId = (langCode: string): string | boolean => {
   if (typeof langCode !== 'string') return false;
   if (langCode in langId) return langId[langCode]; else return false;
 };
 
-translate.getTTSLink = (query: string, languageId: string): string => {
+export const getTTSLink = (query: string, languageId: string): string => {
   const props = stringify({
     ie: 'UTF-8',
     tl: languageId,
@@ -363,7 +363,7 @@ translate.getTTSLink = (query: string, languageId: string): string => {
   return url;
 };
 
-translate.getLangId = (langName: string): string => {
+export const getLangId = (langName: string): string => {
   for (const key in langId) {
     if (langName.toLowerCase() === langId[key].toLowerCase()) {
       return key;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,10 +40,7 @@
     }
   ],
   "background": {
-    "scripts": [
-      "lib/browser-polyfill.min.js",
-      "background/background.js"
-    ]
+    "page": "background/main.html"
   },
   "browser_action": {
     "default_icon": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extName__",
   "short_name": "__MSG_shortName__",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Cudiph",
   "description": "__MSG_extDesc__",
   "default_locale": "en",

--- a/src/options/main.svelte
+++ b/src/options/main.svelte
@@ -9,12 +9,10 @@
   let config = {
     tl: "",
     atl: "",
-    noReferer: true,
   };
-  bslocal.get(["targetLang", "altTargetLang", "noReferer"]).then((res) => {
+  bslocal.get(["targetLang", "altTargetLang"]).then((res) => {
     config.tl = res.targetLang;
     config.atl = res.altTargetLang;
-    config.noReferer = res.noReferer;
   });
 
   function updateTargetLang(e: Event) {
@@ -53,12 +51,6 @@
     });
   }
 
-  function updateNoRef(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    browser.storage.local.set({
-      noReferer: checked,
-    });
-  }
 </script>
 
 {#await config then res}
@@ -85,18 +77,6 @@
           {/each}
         </select>
       </div>
-      <div class="opt-row">
-        <input
-          type="checkbox"
-          name="noref"
-          id="noref"
-          checked={res.noReferer}
-          on:change={updateNoRef}
-        />
-        <label for="noref"
-          >{gm("optionsOmitReferer")}</label
-        >
-      </div>
     </main>
   </div>
 {/await}
@@ -114,8 +94,5 @@
   }
   .opt-row label {
     display: block;
-  }
-  label[for="noref"] {
-    display: inline;
   }
 </style>

--- a/src/popup/Result.svelte
+++ b/src/popup/Result.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
   import { query } from "./store";
   import Collapser from "../lib/Collapser.svelte";
-  import gtrans, { langId, ReadableFormat } from "../lib/gtrans";
+  import { getLangId, langId, ReadableFormat } from "../lib/gtrans";
+
+  const gtrans = async function (
+    text: string,
+    gtransOptions: Record<string, any>
+  ) {
+    return browser.runtime.sendMessage({
+      name: "gtrans-fetch",
+      text,
+      gtransOptions,
+    });
+  };
 
   export let gtransRes: Promise<ReadableFormat>;
   export let targetLang: string;
@@ -17,22 +28,37 @@
   let srcPlaying = false;
   let destPlaying = false;
 
-  function playTTS(query: string, langId: string, forComp: "src" | "dest") {
+  async function playTTS(
+    query: string,
+    langId: string,
+    forComp: "src" | "dest"
+  ) {
+    async function getDataURI(text: string) {
+      const dataURI: string = await browser.runtime.sendMessage({
+        name: "tts-fetch",
+        text: text,
+        langId,
+      });
+      
+      return dataURI;
+    }
+
     if (audio) {
       audio.pause();
       srcPlaying = false;
       destPlaying = false;
     }
     splittedQuery = splitTextToList(query, 200);
-    const ttsLink = gtrans.getTTSLink(splittedQuery[0], langId);
+
+    const dataURI = await getDataURI(splittedQuery[0]);
     audio = new Audio();
-    audio.src = ttsLink;
+    audio.src = dataURI;
     audio.crossOrigin = "anonymous";
     audio.onplay = () => {
       if (forComp === "src") srcPlaying = true;
       else destPlaying = true;
     };
-    audio.onended = () => {
+    audio.onended = async () => {
       // play next audio when ended
       splittedQuery.shift();
       if (splittedQuery.length === 0) {
@@ -40,14 +66,13 @@
         else destPlaying = false;
         return;
       }
-      const ttsLink = gtrans.getTTSLink(splittedQuery[0], langId);
-      audio.src = ttsLink;
+      audio.src = await getDataURI(splittedQuery[0]);
       audio.play();
     };
     audio.onerror = () => {
       srcPlaying = false;
       destPlaying = false;
-    }
+    };
     audio.play();
   }
 
@@ -146,8 +171,8 @@
 {#await gtransRes}
   <p style="margin: 0; padding: 0;">{gm("translateLoading")}</p>
 {:then res}
-  {#if gtrans.getLangId(res.altFrom) === gtrans.getLangId(res.to)}
-    {switchLang(gtrans.getLangId(res.from), res.sourceText)}
+  {#if getLangId(res.altFrom) === res.to}
+    {switchLang(getLangId(res.from), res.sourceText)}
   {/if}
   <div class="translight-result">
     <h3
@@ -165,8 +190,8 @@
       on:change={(e) =>
         updateSource(
           e,
-          gtrans.getLangId(res.altFrom),
-          gtrans.getLangId(res.to),
+          getLangId(res.altFrom),
+          getLangId(res.to),
           res.sourceText,
           res.translated
         )}
@@ -174,7 +199,7 @@
     >
       {#each Object.entries(langId) as [code, language]}
         <option
-          selected={code === gtrans.getLangId(res.altFrom) ? true : false}
+          selected={code === getLangId(res.altFrom) ? true : false}
           value={code}>{language}</option
         >
       {/each}
@@ -189,8 +214,7 @@
         width="24"
         height="24"
         viewBox="0 0 24 24"
-        on:click={() =>
-          playTTS(res.sourceText, gtrans.getLangId(res.altFrom), "src")}
+        on:click={() => playTTS(res.sourceText, getLangId(res.altFrom), "src")}
       >
         <!-- the icon is "stolen" from https://github.com/Templarian/MaterialDesign-SVG -->
         <path
@@ -240,15 +264,15 @@
       on:change={(e) =>
         updateDestination(
           e,
-          gtrans.getLangId(res.altFrom),
-          gtrans.getLangId(res.to),
+          getLangId(res.altFrom),
+          getLangId(res.to),
           res.sourceText,
           res.translated
         )}
     >
       {#each Object.entries(langId) as [code, language]}
         <option
-          selected={code === gtrans.getLangId(res.to) ? true : false}
+          selected={code === getLangId(res.to) ? true : false}
           value={code}>{language}</option
         >
       {/each}
@@ -264,8 +288,7 @@
         height="24"
         viewBox="0 0 24 24"
         style="float: right;"
-        on:click={() =>
-          playTTS(res.translated, gtrans.getLangId(res.to), "dest")}
+        on:click={() => playTTS(res.translated, getLangId(res.to), "dest")}
         ><path
           class="translight-clickable"
           d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z"

--- a/src/popup/Result.svelte
+++ b/src/popup/Result.svelte
@@ -39,7 +39,7 @@
         text: text,
         langId,
       });
-      
+
       return dataURI;
     }
 
@@ -48,6 +48,9 @@
       srcPlaying = false;
       destPlaying = false;
     }
+    if (forComp === "src") srcPlaying = true;
+    else destPlaying = true;
+
     splittedQuery = splitTextToList(query, 200);
 
     const dataURI = await getDataURI(splittedQuery[0]);


### PR DESCRIPTION
## Problem
Omitting `referer` header in http request causes some websites to not work especially when authenticating. And for chromium based browser, the page's CSP and CORS is also applied to content script thus making request in content script to different domain is not possible.

## Solution
Move fetch to background script and using messaging APIs to transfer data from content script to background script and vice versa.

### Other problem
Because CSP applied to content script, tts is not going to work in inline popup if the page define `media-src` rule except `media-src` allow `data:` in its value (the audio file is converted to base64 data URL because chromium doesn't implement `structuredClone` yet in their messaging API). Meanwhile in Firefox, it works out of the box without doing anything complicated :D

### Solution
If tts didn't play after clicking the audio icon you can use toolbar popup instead.
